### PR TITLE
Debian 11 (bullseye) supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note: We moved this repository to [a new location](http://github.com/i-doit/scri
 ### Added
 
 -   `idoit-install`: Add support for CentOS 8
+-   `idoit-install`: Add support for Debian 11 "bullseye"
 -   `idoit-install`: Add support for Ubuntu Linux 20.04 LTS "focal fossa"
 -   `idoit-install`: Add support for openSUSE "leap" 15, 15.1 and 15.2
 -   `idoit-install`: Add new logic to configure MariaDB based on the operating system and MariaDB version used

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The script [`idoit-install`](idoit-install) allows you to easily install the **l
 
 on a **fresh installation of a GNU/Linux operating system**. Supported OSs are:
 
--   Debian GNU/Linux 10 "buster" (**recommended**)
+-   Debian GNU/Linux 10 "buster" , DebianGNU/Linux 11 (bullseye) (**recommended**)
 -   Ubuntu Linux 18.04 LTS "bionic" and 20.04 LTS "focal fossa"
 -   Red Hat Enterprise Linux (RHEL) 7 (deprecated) and (RHEL) 8
 -   CentOS 7 (deprecated) and CentOS 8

--- a/idoit-install
+++ b/idoit-install
@@ -289,6 +289,21 @@ function identifyOS {
         MARIADB_UNIT="mariadb"
         MEMCACHED_UNIT="memcached"
         PHP_FPM_UNIT="php-fpm"
+    elif [[ "$NAME" == "Debian GNU/Linux" && "$VERSION" == "11 (bullseye)" ]]; then
+            export DEBIAN_FRONTEND="noninteractive"
+
+            OS="debian11"
+            APACHE_USER="www-data"
+            APACHE_GROUP="www-data"
+            APACHE_CONFIG_FILE="/etc/apache2/sites-available/i-doit.conf"
+            MARIADB_CONFIG_FILE="/etc/mysql/mariadb.conf.d/99-i-doit.cnf"
+            PHP_CONFIG_FILE="/etc/php/7.4/mods-available/i-doit.ini"
+            MARIADB_SOCKET="/var/run/mysqld/mysqld.sock"
+            PHP_FPM_SOCKET="/var/run/php/php7.4-fpm.sock"
+            APACHE_UNIT="apache2"
+            MARIADB_UNIT="mysql"
+            MEMCACHED_UNIT="memcached"
+            PHP_FPM_UNIT="php7.4-fpm"
     elif [[ "$NAME" == "Debian GNU/Linux" && "$VERSION" == "10 (buster)" ]]; then
         export DEBIAN_FRONTEND="noninteractive"
 
@@ -529,6 +544,9 @@ function checkSoftwareRequirements {
 
 function configureOS {
     case "$OS" in
+        "debian11")
+            configureDebian11
+            ;;
         "debian10")
             configureDebian10
             ;;
@@ -559,6 +577,24 @@ function configureOS {
         *)
             abort "Unkown operating system '${OS}'!?!"
     esac
+}
+
+function configureDebian11 {
+    log "Keep your Debian packages up-to-date"
+    apt-get -qq --yes update || abort "Unable to update Debian package repositories"
+    apt-get -qq --yes full-upgrade || abort "Unable to perform update of Debian packages"
+    apt-get -qq --yes clean || abort "Unable to cleanup Debian packages"
+    apt-get -qq --yes autoremove || abort "Unable to remove unnecessary Debian packages"
+
+    log "Install required Debian packages"
+    apt-get -qq --yes install --no-install-recommends \
+        apache2 libapache2-mod-fcgid \
+        mariadb-client mariadb-server \
+        php7.4-bcmath php7.4-cli php7.4-common php7.4-curl php7.4-fpm php7.4-gd php7.4-json \
+        php7.4-ldap php7.4-mbstring php7.4-mysql php7.4-opcache php7.4-pgsql \
+        php7.4-soap php7.4-xml php7.4-zip \
+        php-memcached \
+        memcached unzip sudo moreutils || abort "Unable to install required Debian packages"
 }
 
 function configureDebian10 {
@@ -1310,7 +1346,7 @@ EOF
 
             unitctl "restart" "$APACHE_UNIT"
             ;;
-        "debian10"|"ubuntu1604"|"ubuntu1804"|"ubuntu2004")
+        "debian11"|"debian10"|"ubuntu1604"|"ubuntu1804"|"ubuntu2004")
             a2_en_site=$(command -v a2ensite)
             a2_dis_site=$(command -v a2dissite)
             a2_en_mod=$(command -v a2enmod)
@@ -1580,7 +1616,7 @@ function secureMariaDB {
                 abort "SQL statement failed"
             ;;
 
-        "sles15"|"opensuse15"|"debian10"|"ubuntu1804"|"ubuntu2004")
+        "sles15"|"opensuse15"|"debian10"|"debian11"|"ubuntu1804"|"ubuntu2004")
             log "Allow $MARIADB_SUPERUSER_USERNAME login only from localhost"
             "$MARIADB_BIN" \
                 -h"$MARIADB_HOSTNAME" \


### PR DESCRIPTION
Add support for Debian 11 "bullseye"
The support for Debian 11 "bullseye" has been added.

### Added

-   Support for Debian 11 "bullseye"

### Changed

-   Added the change for Debian 11 to the changelog
-   Added Debian 11 to the readme
