### PR TITLE
openSUSE 15.3 and SLES 15 SP3 and modify PHP version standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Note: We moved this repository to [a new location](http://github.com/i-doit/scri
 -   `idoit-install`: Fix hardware checks because of wrong locale (found on Ubuntu 18.04 LTS)
 -   `idoit-support`: Add missing destination for file `appliance_version`
 -   `idoit-install`: Fix missing authentication statement for MariaDB configuration
+-   `idoit-install`: Fix PHP version checker to support the recommended PHP version
+
 
 ## [0.13][] – 2019-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Note: We moved this repository to [a new location](http://github.com/i-doit/scri
 -   `idoit-install`: Add support for CentOS 8
 -   `idoit-install`: Add support for Debian 11 "bullseye"
 -   `idoit-install`: Add support for Ubuntu Linux 20.04 LTS "focal fossa"
--   `idoit-install`: Add support for openSUSE "leap" 15, 15.1 and 15.2
+-   `idoit-install`: Add support for openSUSE "leap" 15, 15.1, 15.2 and 15.3
 -   `idoit-install`: Add new logic to configure MariaDB based on the operating system and MariaDB version used
 -   `idoit-install`: Add support for MariaDB 10.4 and MariaDB 10.5
 -   `idoit-install`: Added "create_tenant" function to "function execute"

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ on a **fresh installation of a GNU/Linux operating system**. Supported OSs are:
 -   Ubuntu Linux 18.04 LTS "bionic" and 20.04 LTS "focal fossa"
 -   Red Hat Enterprise Linux (RHEL) 7 (deprecated) and (RHEL) 8
 -   CentOS 7 (deprecated) and CentOS 8
--   SUSE Linux Enterprise Server 15, 15 SP1 and 15 SP2
--   openSUSE "leap" 15, 15.1 and 15.2
+-   SUSE Linux Enterprise Server 15, 15 SP1, 15 SP2 and 15 SP3
+-   openSUSE "leap" 15, 15.1, 15.2 and 15.3
 
 Before you execute this script you …
 

--- a/idoit-install
+++ b/idoit-install
@@ -1147,14 +1147,14 @@ function configurePHP {
     php_version=$(php --version | head -n1 -c7 | tail -c3)
 
     case "$php_version" in
-        "5.4"|"5.5"|"5.6"|"7.0")
+        "5.4"|"5.5"|"5.6"|"7.0"|"7.1"|"7.2")
             abort "PHP ${php_version} is way too old. Please upgrade. We recommend version ${RECOMMENDED_PHP_VERSION}."
             ;;
-        "7.1")
+        "7.3")
             log "PHP ${php_version} is installed, but this version is deprecated. Please consider to upgrade. We recommend version ${RECOMMENDED_PHP_VERSION}."
             php_en_mod=$(command -v phpenmod)
             ;;
-        "7.2"|"7.3"|"7.4")
+        "7.4")
             php_en_mod=$(command -v phpenmod)
             ;;
         "8.0")


### PR DESCRIPTION
Short description

Long description

### Added

-   Support for openSUSE Leap 15.3 and SLES 15 SP3


### Changed

-   Set PHP 7.1 and 7.2 as too old
-   Deprecate PHP 7.3
