### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ chmod 755 idoit-install
 Either run the script as `root`:
 
 ~~~ {.bash}
-su
+su -
 ./idoit-install
 ~~~
 


### PR DESCRIPTION
Altered `su` to `su -` for Debian, `/usr/sbin` is no longer passed in PATH with "su".