### PR TITLE
Ubuntu 22.04 "jammy jellyfish" and modify recommend PHP and MariaDB Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ Note: We moved this repository to [a new location](http://github.com/i-doit/scri
 
 -   `idoit-install`: Add support for CentOS 8
 -   `idoit-install`: Add support for Debian 11 "bullseye"
--   `idoit-install`: Add support for Ubuntu Linux 20.04 LTS "focal fossa"
+-   `idoit-install`: Add support for Ubuntu Linux 20.04 LTS "focal fossa" and 22.04 LTS "jammy jellyfish"
 -   `idoit-install`: Add support for openSUSE "leap" 15, 15.1, 15.2 and 15.3
 -   `idoit-install`: Add new logic to configure MariaDB based on the operating system and MariaDB version used
--   `idoit-install`: Add support for MariaDB 10.4 and MariaDB 10.5
+-   `idoit-install`: Add support for MariaDB 10.4, 10.5 and 10.6
 -   `idoit-install`: Added "create_tenant" function to "function execute"
 
 ### Changed
@@ -27,15 +27,17 @@ Note: We moved this repository to [a new location](http://github.com/i-doit/scri
 -   `idoit-install`: Mark PHP 5.6 and PHP 7.0 as unsupported
 -   `idoit-install`: Mark PHP 7.1 as deprecated
 -   `idoit-install`: Mark PHP 7.4 as stable
--   `idoit-install`: Mark PHP 8.0 as unsupported
--   `idoit-install`: Mark MariaDB 10.5 as recommended
--   `idoit-install`: Mark PHP 7.4 as recommended
+-   `idoit-install`: Mark PHP 8.0 as supported
+-   `idoit-install`: Mark PHP 8.1 as supported
+-   `idoit-install`: Mark MariaDB 10.6 as recommended
+-   `idoit-install`: Mark PHP 8.0 as recommended
 -   `idoit-install`: Deprecate support for RHEL 7
 -   `idoit-install`: Deprecate support for CentOS 7
 -   `idoit-install`: Remove support for Debian GNU/Linux 9 "stretch"
 -   `idoit-install`: Remove support for Ubuntu Linux 16.04 LTS "xenial"
 -   `idoit-install`: Remove support for SLES 12
--   `idoit-install`: Changed Copyright to 2022
+-   `idoit-install`: Remove outdated i-doit controller
+-   `idoit-install`: Changed Copyright to 2023
 -   `idoit-install`: Changed installIDoit to use console.php for installation
 -   `idoit-install`: Changed installIDoit to use console.php for tenant creation
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The script [`idoit-install`](idoit-install) allows you to easily install the **l
 on a **fresh installation of a GNU/Linux operating system**. Supported OSs are:
 
 -   Debian GNU/Linux 10 "buster" , DebianGNU/Linux 11 (bullseye) (**recommended**)
--   Ubuntu Linux 18.04 LTS "bionic" and 20.04 LTS "focal fossa"
+-   Ubuntu Linux 18.04 LTS "bionic", 20.04 LTS "focal fossa" and 22.04 LTS "jammy jellyfish"
 -   Red Hat Enterprise Linux (RHEL) 7 (deprecated) and (RHEL) 8
 -   CentOS 7 (deprecated) and CentOS 8
 -   SUSE Linux Enterprise Server 15, 15 SP1, 15 SP2 and 15 SP3
@@ -245,6 +245,6 @@ Please, report any issues to [our issue tracker](https://github.com/i-doit/scrip
 
 ## Copyright & license
 
-Copyright (C) 2017-21 [synetics GmbH](https://i-doit.com/)
+Copyright (C) 2017-23 [synetics GmbH](https://i-doit.com/)
 
 Licensed under the [GNU Affero GPL version 3 or later (AGPLv3+)](https://gnu.org/licenses/agpl.html). This is free software: you are free to change and redistribute it. There is NO WARRANTY, to the extent permitted by law.

--- a/idoit-install
+++ b/idoit-install
@@ -1190,6 +1190,7 @@ function configurePHP {
             abort "PHP ${php_version} is way too old. Please upgrade. We recommend version ${RECOMMENDED_PHP_VERSION}."
             ;;
         "7.4")
+            log "PHP ${php_version} is installed, but this version is deprecated. Please consider to upgrade. We recommend version ${RECOMMENDED_PHP_VERSION}."
             php_en_mod=$(command -v phpenmod)
             ;;
         "8.0")

--- a/idoit-install
+++ b/idoit-install
@@ -51,8 +51,8 @@ IFS=$'\n\t'
 : "${JOBS_BIN:="/usr/local/bin/idoit-jobs"}"
 : "${CRON_FILE:="/etc/cron.d/i-doit"}"
 : "${BACKUP_DIR:="/var/backups/i-doit"}"
-: "${RECOMMENDED_PHP_VERSION:="7.4"}"
-: "${RECOMMENDED_MARIADB_VERSION:="10.5"}"
+: "${RECOMMENDED_PHP_VERSION:="8.0"}"
+: "${RECOMMENDED_MARIADB_VERSION:="10.6"}"
 
 ##
 ## Runtime settings

--- a/idoit-install
+++ b/idoit-install
@@ -390,6 +390,20 @@ function identifyOS {
     elif [[ "$NAME" = "openSUSE" && "$VERSION_ID" == 12* ]]; then
         abort "Error: openSUSE 12 is out-dated. It's not supported anymore. Please upgrade."
 
+    elif [[ "$NAME" == "Ubuntu" && "$VERSION_ID" == "22.04" ]]; then
+            export DEBIAN_FRONTEND="noninteractive"
+            OS="ubuntu2204"
+            APACHE_USER="www-data"
+            APACHE_GROUP="www-data"
+            APACHE_CONFIG_FILE="/etc/apache2/sites-available/i-doit.conf"
+            MARIADB_CONFIG_FILE="/etc/mysql/mariadb.conf.d/99-i-doit.cnf"
+            PHP_CONFIG_FILE="/etc/php/8.1/mods-available/i-doit.ini"
+            MARIADB_SOCKET="/var/run/mysqld/mysqld.sock"
+            PHP_FPM_SOCKET="/var/run/php/php8.1-fpm.sock"
+            APACHE_UNIT="apache2"
+            MARIADB_UNIT="mysql"
+            MEMCACHED_UNIT="memcached"
+            PHP_FPM_UNIT="php8.1-fpm"
     elif [[ "$NAME" == "Ubuntu" && "$VERSION_ID" == "20.04" ]]; then
         export DEBIAN_FRONTEND="noninteractive"
         OS="ubuntu2004"
@@ -554,6 +568,9 @@ function configureOS {
         "debian10")
             configureDebian10
             ;;
+        "ubuntu2204")
+            configureUbuntu2204
+            ;;
         "ubuntu2004")
             configureUbuntu2004
             ;;
@@ -684,6 +701,24 @@ function configureUbuntu2004 {
         php7.4-bcmath php7.4-cli php7.4-common php7.4-curl php7.4-fpm php7.4-gd php7.4-json \
         php7.4-ldap php7.4-mbstring php7.4-mysql php7.4-opcache php7.4-pgsql \
         php7.4-soap php7.4-xml php7.4-zip \
+        php-memcached \
+        memcached unzip moreutils || abort "Unable to install required Ubuntu packages"
+}
+
+function configureUbuntu2204 {
+    log "Keep your Ubuntu packages up-to-date"
+    apt-get -qq --yes update || abort "Unable to update Ubuntu package repositories"
+    apt-get -qq --yes full-upgrade || abort "Unable to perform update of Ubuntu packages"
+    apt-get -qq --yes clean || abort "Unable to cleanup Ubuntu packages"
+    apt-get -qq --yes autoremove || abort "Unable to remove unnecessary Ubuntu packages"
+
+    log "Install required Ubuntu packages"
+    apt-get -qq --yes install --no-install-recommends \
+        apache2 libapache2-mod-fcgid \
+        mariadb-client mariadb-server \
+        php8.1-bcmath php8.1-cli php8.1-common php8.1-curl php8.1-fpm php8.1-gd \
+        php8.1-ldap php8.1-mbstring php8.1-mysql php8.1-opcache php8.1-pgsql \
+        php8.1-soap php8.1-xml php8.1-zip \
         php-memcached \
         memcached unzip moreutils || abort "Unable to install required Ubuntu packages"
 }
@@ -1151,18 +1186,17 @@ function configurePHP {
     php_version=$(php --version | head -n1 -c7 | tail -c3)
 
     case "$php_version" in
-        "5.4"|"5.5"|"5.6"|"7.0"|"7.1"|"7.2")
+        "5.4"|"5.5"|"5.6"|"7.0"|"7.1"|"7.2"|"7.3")
             abort "PHP ${php_version} is way too old. Please upgrade. We recommend version ${RECOMMENDED_PHP_VERSION}."
-            ;;
-        "7.3")
-            log "PHP ${php_version} is installed, but this version is deprecated. Please consider to upgrade. We recommend version ${RECOMMENDED_PHP_VERSION}."
-            php_en_mod=$(command -v phpenmod)
             ;;
         "7.4")
             php_en_mod=$(command -v phpenmod)
             ;;
         "8.0")
-            abort "PHP ${php_version} is installed, but this version is not suitable in a productive environment. Please consider to downgrade. We recommend version ${RECOMMENDED_PHP_VERSION}."
+            php_en_mod=$(command -v phpenmod)
+            ;;
+        "8.1")
+            php_en_mod=$(command -v phpenmod)
             ;;
         *)
             abort "PHP ${php_version} is not supported. Please follow the system requirements. We recommend version ${RECOMMENDED_PHP_VERSION}."
@@ -1210,7 +1244,7 @@ function configurePHPFPM {
     log "Configure PHP-FPM"
 
     case "$OS" in
-        "debian10"|"debian11"|"ubuntu1804"|"ubuntu2004")
+        "debian10"|"debian11"|"ubuntu1804"|"ubuntu2004"|"ubuntu2204")
             unitctl "restart" "$PHP_FPM_UNIT"
             ;;
         "rhel7"|"rhel8"|"centos7"|"centos8")
@@ -1383,7 +1417,7 @@ EOF
 
             unitctl "restart" "$APACHE_UNIT"
             ;;
-        "debian11"|"debian10"|"ubuntu1604"|"ubuntu1804"|"ubuntu2004")
+        "debian11"|"debian10"|"ubuntu1604"|"ubuntu1804"|"ubuntu2004"|"ubuntu2204")
             a2_en_site=$(command -v a2ensite)
             a2_dis_site=$(command -v a2dissite)
             a2_en_mod=$(command -v a2enmod)
@@ -1594,7 +1628,7 @@ function secureMariaDB {
 
     log "Set $MARIADB_SUPERUSER_USERNAME password and plugin 'mysql_native_password'"
     case "$mariadb_version" in
-        "10.4"|"10.5")
+        "10.4"|"10.5"|"10.6")
             "$MARIADB_BIN" \
             -h"$MARIADB_HOSTNAME" \
             -u"$MARIADB_SUPERUSER_USERNAME" \
@@ -1653,7 +1687,7 @@ function secureMariaDB {
                 abort "SQL statement failed"
             ;;
 
-        "sles15"|"opensuse15"|"debian10"|"debian11"|"ubuntu1804"|"ubuntu2004")
+        "sles15"|"opensuse15"|"debian10"|"debian11"|"ubuntu1804"|"ubuntu2004"|"ubuntu2204")
             log "Allow $MARIADB_SUPERUSER_USERNAME login only from localhost"
             "$MARIADB_BIN" \
                 -h"$MARIADB_HOSTNAME" \

--- a/idoit-install
+++ b/idoit-install
@@ -1800,8 +1800,6 @@ EOF
     chown "$APACHE_USER":"$APACHE_GROUP" -R . || abort "Unable to change ownership"
     find . -type d -name \* -exec chmod 775 {} \; || abort "Unable to change directory permissions"
     find . -type f -exec chmod 664 {} \; || abort "Unable to change file permissions"
-    chmod 774 controller ./*.sh setup/*.sh || \
-        abort "Unable to change executable permissions"
 }
 
 function updateApacheConfig {


### PR DESCRIPTION

### Added

-   Support for Ubuntu 22.04 "jammy jellyfish"
-   Support for PHP 8.0 and 8.1
-   Support for MariaDB 10.6


### Changed

-   Set PHP 8.0 as recommended
-   Set MariaDB 10.6 as recommended

### Removed

-   Support for PHP 7.3
-   Usage of outdated i-doit controller
