### PR TITLE
Update idoit-install variant hint

### DIFF
--- a/idoit-install
+++ b/idoit-install
@@ -1737,6 +1737,12 @@ function prepareIDoit {
     log "Cleanup VHost directory"
     rm -rf "${INSTALL_DIR:?}/"* || abort "Unable to remove files"
     rm -f "${INSTALL_DIR}"/.htaccess || abort "Unable to remove files"
+    
+    log ""
+    echo -e "For evaluation use \033[32mEVAL\033[0m"
+    echo -e "If you have a license use \033[32mPRO\033[0m"
+    echo -e "If you want the open version use \033[32mOPEN\033[0m"
+    log ""
 
     echo -n -e "Which variant of i-doit do you like to install? [EVAL|pro|open]: "
 

--- a/idoit-install
+++ b/idoit-install
@@ -1739,9 +1739,9 @@ function prepareIDoit {
     rm -f "${INSTALL_DIR}"/.htaccess || abort "Unable to remove files"
     
     log ""
-    echo -e "For evaluation use \033[32mEVAL\033[0m"
-    echo -e "If you have a license use \033[32mPRO\033[0m"
-    echo -e "If you want the open version use \033[32mOPEN\033[0m"
+    log "For evaluation use \033[32mEVAL\033[0m"
+    log "If you have a license use \033[32mPRO\033[0m"
+    log "If you want the open version use \033[32mOPEN\033[0m"
     log ""
 
     echo -n -e "Which variant of i-doit do you like to install? [EVAL|pro|open]: "


### PR DESCRIPTION
A customer installed PRO instead of EVAL because there was no hint
